### PR TITLE
Bypass cdn for readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ the [Security TechCenter](https://technet.microsoft.com/en-us/security/default).
 [Build Latest]: https://msasg.visualstudio.com/Falcon/_build/latest?definitionId=6598&branch=master
 [Choco Status]: https://img.shields.io/myget/atlas-ci/vpre/atlas-cli.svg?label=choco
 [Choco Latest]: #chocolatey
-[Zip Status]: https://img.shields.io/badge/dynamic/json.svg?label=win-x64&url=https%3A%2F%2Fep2fitssy3mz7ig.azureedge.net%2Fdownloads%2Flatest.json&query=%24[%27win10-x64%27].version
-[Zip Latest]: https://ep2fitssy3mz7ig.azureedge.net/downloads/atlas-latest-win10-x64.zip
-[Tarball Status]: https://img.shields.io/badge/dynamic/json.svg?label=linux-x64&url=https%3A%2F%2Fep2fitssy3mz7ig.azureedge.net%2Fdownloads%2Flatest.json&query=%24[%27linux-x64%27].version
-[Tarball Latest]: https://ep2fitssy3mz7ig.azureedge.net/downloads/atlas-latest-linux-x64.tar.gz
+[Zip Status]: https://img.shields.io/badge/dynamic/json.svg?label=win-x64&url=https%3A%2F%2Fsa2fitssy3mz7ig.blob.core.windows.net%2Fdownloads%2Flatest.json&query=%24[%27win10-x64%27].version
+[Zip Latest]: https://sa2fitssy3mz7ig.blob.core.windows.net/downloads/atlas-latest-win10-x64.zip
+[Tarball Status]: https://img.shields.io/badge/dynamic/json.svg?label=linux-x64&url=https%3A%2F%2Fsa2fitssy3mz7ig.blob.core.windows.net%2Fdownloads%2Flatest.json&query=%24[%27linux-x64%27].version
+[Tarball Latest]: https://sa2fitssy3mz7ig.blob.core.windows.net/downloads/atlas-latest-linux-x64.tar.gz
 [Master Branch]: https://github.com/microsoft/atlas/tree/master
-[Latest Json]: https://ep2fitssy3mz7ig.azureedge.net/downloads/latest.json
+[Latest Json]: https://sa2fitssy3mz7ig.blob.core.windows.net/downloads/latest.json


### PR DESCRIPTION
* Version numbers on shield not updating reliably
* Using blob storage directly until bypass policy sorted out