### PR TITLE
Install sleet in bin subfolder

### DIFF
--- a/examples/402-cdn-with-storage-account/sleet-push.cmd
+++ b/examples/402-cdn-with-storage-account/sleet-push.cmd
@@ -1,3 +1,3 @@
-dotnet tool install -g sleet
-sleet init --source packages
-sleet push {{ latest.drop }}\tools --source packages
+dotnet tool install sleet --tool-path .\bin
+.\bin\sleet init --source packages
+.\bin\sleet push {{ latest.drop }}\tools --source packages

--- a/examples/402-cdn-with-storage-account/sleet-push.sh
+++ b/examples/402-cdn-with-storage-account/sleet-push.sh
@@ -1,3 +1,3 @@
-dotnet tool install -g sleet
-sleet init --source packages
-sleet push {{ latest.drop }}/tools --source packages
+dotnet tool install sleet --tool-path ./bin
+./bin/sleet init --source packages
+./bin/sleet push {{ latest.drop }}/tools --source packages


### PR DESCRIPTION
* less likely to collide on build agent
* avoids problem where install -g isn't already on path