### PR TITLE
More helpers for devops api

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
 
   <PropertyGroup>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)build\analyzers.ruleset</CodeAnalysisRuleSet>
-    <TreatWarningsAsErrors Condition=" '$(Configuration)' == 'Debug' ">true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition=" '$(Configuration)' == 'Release' ">true</TreatWarningsAsErrors>
     <WarningsAsErrors />
 
     <!-- CS7034: The specified version string does not conform to the required format - major[.minor[.build[.revision]]] -->

--- a/src/Microsoft.Atlas.CommandLine/Queries/BitsFunction.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/BitsFunction.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using DevLab.JmesPath.Functions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Atlas.CommandLine.Queries
+{
+    public class BitsFunction : JmesPathFunction
+    {
+        public BitsFunction()
+            : base("bits", 1, true)
+        {
+        }
+
+        public override void Validate(params JmesPathFunctionArgument[] args)
+        {
+            base.Validate();
+            EnsureNumbers(args);
+        }
+
+        public override JToken Execute(params JmesPathFunctionArgument[] args)
+        {
+            ulong bits = 0;
+            foreach (var argument in args)
+            {
+                bits |= argument.Token.Value<ulong>();
+            }
+
+            var result = new JArray();
+            for (var bit = 0; bit < 64; ++bit)
+            {
+                var mask = 1ul << bit;
+                if ((bits & mask) == mask)
+                {
+                    result.Add(new JValue(mask));
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Microsoft.Atlas.CommandLine/Queries/DistinctByFunction.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/DistinctByFunction.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DevLab.JmesPath.Functions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Atlas.CommandLine.Queries
+{
+    public class DistinctByFunction : ByFunction
+    {
+        public DistinctByFunction()
+            : base("distinct_by")
+        {
+        }
+
+        public override JToken Execute(params JmesPathFunctionArgument[] args)
+        {
+            var array = (JArray)args[0].Token;
+            var expression = args[1].Expression;
+
+            var comparer = new Comparer(u => expression.Transform(u).AsJToken());
+
+            var distinct = array.Children().Distinct(comparer);
+
+            return new JArray(distinct.Cast<object>().ToArray());
+        }
+
+        private class Comparer : IEqualityComparer<JToken>
+        {
+            private readonly Func<JToken, JToken> _keySelector;
+
+            public Comparer(Func<JToken, JToken> keySelector)
+            {
+                _keySelector = keySelector;
+            }
+
+            public bool Equals(JToken x, JToken y)
+            {
+                return JToken.EqualityComparer.Equals(_keySelector(x), _keySelector(y));
+            }
+
+            public int GetHashCode(JToken obj)
+            {
+                return JToken.EqualityComparer.GetHashCode(_keySelector(obj));
+            }
+        }
+    }
+}

--- a/src/Microsoft.Atlas.CommandLine/Queries/DistinctFunction.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/DistinctFunction.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DevLab.JmesPath.Functions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Atlas.CommandLine.Queries
+{
+    public class DistinctFunction : JmesPathFunction
+    {
+        public DistinctFunction()
+            : base("distinct", 1)
+        {
+        }
+
+        public override JToken Execute(params JmesPathFunctionArgument[] args)
+        {
+            var array = (JArray)args[0].Token;
+
+            var distinct = array.Children().Distinct(JToken.EqualityComparer);
+
+            return new JArray(distinct.Cast<object>().ToArray());
+        }
+    }
+}

--- a/src/Microsoft.Atlas.CommandLine/Queries/JmesPathQuery.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/JmesPathQuery.cs
@@ -21,7 +21,10 @@ namespace Microsoft.Atlas.CommandLine.Queries
             _jmespath.FunctionRepository
                 .Register<ItemsFunction>()
                 .Register<ToObjectFunction>()
-                .Register<ZipFunction>();
+                .Register<ZipFunction>()
+                .Register<DistinctByFunction>()
+                .Register<DistinctFunction>()
+                .Register<BitsFunction>();
             _serializers = serializers;
         }
 

--- a/src/Microsoft.Atlas.CommandLine/Templates/TemplateEngine.cs
+++ b/src/Microsoft.Atlas.CommandLine/Templates/TemplateEngine.cs
@@ -12,6 +12,7 @@ using DevLab.JmesPath;
 using DevLab.JmesPath.Functions;
 using HandlebarsDotNet;
 using HandlebarsDotNet.Compiler;
+using Microsoft.Atlas.CommandLine.Queries;
 using Microsoft.Atlas.CommandLine.Templates.FileSystems;
 using Microsoft.Atlas.CommandLine.Templates.TextWriters;
 
@@ -282,15 +283,7 @@ namespace Microsoft.Atlas.CommandLine.Templates
             var query = string.Format(formatString, args: formatArguments.ToArray());
             var json = arguments.OfType<HashParameterDictionary>().SingleOrDefault() ?? (object)context;
 
-            var jmespath = new JmesPath();
-            jmespath.FunctionRepository
-                .Register<ItemsFunction>()
-                .Register<ToObjectFunction>()
-                .Register<ZipFunction>();
-
-            var token = Services.Serializers.JTokenTranserializer(json);
-            var transformOutput = jmespath.Transform(token, query);
-            var transformObject = Services.Serializers.YamlDeserializer.Deserialize<object>(transformOutput.ToString());
+            var transformObject = Services.JmesPathQuery.Search(query, json);
 
             return transformObject;
         }

--- a/src/Microsoft.Atlas.CommandLine/Templates/TemplateEngineServices.cs
+++ b/src/Microsoft.Atlas.CommandLine/Templates/TemplateEngineServices.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 using System.Collections.Generic;
+using Microsoft.Atlas.CommandLine.Queries;
 using Microsoft.Atlas.CommandLine.Secrets;
 using Microsoft.Atlas.CommandLine.Serialization;
 using Microsoft.Atlas.CommandLine.Templates.Helpers;
@@ -13,11 +14,13 @@ namespace Microsoft.Atlas.CommandLine.Templates
         public TemplateEngineServices (
             IYamlSerializers serializers,
             ISecretTracker secretTracker,
-            IEnumerable<ITemplateHelperProvider> templateHelperProviders)
+            IEnumerable<ITemplateHelperProvider> templateHelperProviders,
+            IJmesPathQuery jmesPathQuery)
         {
             Serializers = serializers;
             SecretTracker = secretTracker;
             TemplateHelperProviders = templateHelperProviders;
+            JmesPathQuery = jmesPathQuery;
         }
 
         public IYamlSerializers Serializers { get; }
@@ -25,5 +28,7 @@ namespace Microsoft.Atlas.CommandLine.Templates
         public ISecretTracker SecretTracker { get; }
 
         public IEnumerable<ITemplateHelperProvider> TemplateHelperProviders { get; }
+
+        public IJmesPathQuery JmesPathQuery { get; }
     }
 }

--- a/test/Microsoft.Atlas.CommandLine.Tests/Queries/BaseFunctionTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Queries/BaseFunctionTests.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Atlas.CommandLine.Queries;
+using Microsoft.Atlas.CommandLine.Serialization;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.Atlas.CommandLine.Tests.Queries
+{
+    public abstract class BaseFunctionTests
+    {
+        public IJmesPathQuery Query { get; set; } = new JmesPathQuery(new YamlSerializers());
+
+        public T Yaml<T>(string input) => new YamlSerializers().YamlDeserializer.Deserialize<T>(input);
+
+        public IDictionary<string, object> Yaml(string input) => Yaml<IDictionary<string, object>>(input);
+    }
+}

--- a/test/Microsoft.Atlas.CommandLine.Tests/Queries/BitsFunctionTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Queries/BitsFunctionTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Atlas.CommandLine.Queries;
+using Microsoft.Atlas.CommandLine.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Atlas.CommandLine.Tests.Queries
+{
+    [TestClass]
+    public class BitsFunctionTests
+    {
+        [TestMethod]
+        public void BitsTurnsNumberIntoArray()
+        {
+            var query = new JmesPathQuery(new YamlSerializers());
+
+            var result = (List<object>)query.Search("bits(`9`)", null);
+
+            Assert.AreEqual(2, result.Count());
+            Assert.AreEqual(1, result[0]);
+            Assert.AreEqual(8, result[1]);
+        }
+
+        [TestMethod]
+        public void MultipleNumbersAreBitwiseOredTogether()
+        {
+            var query = new JmesPathQuery(new YamlSerializers());
+
+            var result = (List<object>)query.Search("bits(`9`, `5`)", null);
+
+            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual(1, result[0]);
+            Assert.AreEqual(4, result[1]);
+            Assert.AreEqual(8, result[2]);
+        }
+
+        [TestMethod]
+        public void NumbersCanComeFromContext()
+        {
+            var query = new JmesPathQuery(new YamlSerializers());
+            var context = new Dictionary<string, object>
+            {
+                { "x", 18 }
+            };
+
+            var result = (List<object>)query.Search("bits(x)", context);
+
+            Assert.AreEqual(2, result.Count());
+            Assert.AreEqual(2, result[0]);
+            Assert.AreEqual(16, result[1]);
+        }
+    }
+}

--- a/test/Microsoft.Atlas.CommandLine.Tests/Queries/DistinctFunctionTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Queries/DistinctFunctionTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Atlas.CommandLine.Queries;
+using Microsoft.Atlas.CommandLine.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Atlas.CommandLine.Tests.Queries
+{
+    [TestClass]
+    public class DistinctFunctionTests : BaseFunctionTests
+    {
+        [TestMethod]
+        [DataRow("distinct(data)")]
+        [DataRow("distinct_by(data, &@)")]
+        public void DistinctEmptyArrayIsEmpty(string expression)
+        {
+            var context = Yaml("data: []");
+
+            var result = (List<object>)Query.Search(expression, context);
+
+            Assert.AreEqual(0, result.Count());
+        }
+
+        [TestMethod]
+        [DataRow("distinct(data)")]
+        [DataRow("distinct_by(data, &@)")]
+        public void NumbersAreDistinct(string expression)
+        {
+            var context = Yaml("data: [5,9,5]");
+
+            var result = (List<object>)Query.Search(expression, context);
+
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.Contains(5));
+            Assert.IsTrue(result.Contains(9));
+        }
+
+        [TestMethod]
+        [DataRow("distinct(data)")]
+        [DataRow("distinct_by(data, &@)")]
+        public void StringsAreDistinct(string expression)
+        {
+            var context = Yaml("data: [one,two,one]");
+
+            var result = (List<object>)Query.Search(expression, context);
+
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.Contains("one"));
+            Assert.IsTrue(result.Contains("two"));
+        }
+
+        [TestMethod]
+        [DataRow("distinct(data)")]
+        [DataRow("distinct_by(data, &@)")]
+        public void StringAndNumbersAreDifferent(string expression)
+        {
+            var context = Yaml("data: [5,5,'5',5,'5']");
+
+            var result = (List<object>)Query.Search(expression, context);
+
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.Contains("5"));
+            Assert.IsTrue(result.Contains(5));
+        }
+
+        [TestMethod]
+        [DataRow("distinct_by(data, &x)")]
+        public void DistinctByFunctionForProperty(string expression)
+        {
+            var context = Yaml(@"
+data: 
+- x: one
+  y: alpha
+- x: two
+  y: beta
+- x: one
+  y: gamma
+");
+
+            var result = (List<object>)Query.Search("distinct_by(data, &x)", context);
+            var keys = result.Cast<IDictionary<object, object>>().Select(item => item["x"]).Cast<string>();
+
+            Assert.AreEqual(2, result.Count());
+            Assert.AreEqual(2, keys.Count());
+            Assert.IsTrue(keys.Contains("one"));
+            Assert.IsTrue(keys.Contains("two"));
+        }
+    }
+}


### PR DESCRIPTION
For a workflow that reported the access control lists on build or release definitions... Needed to split a number into bits (for allow/deny bitmasks), and to find distinct values (to lookup identities of access control entries).