### PR TITLE
Moving operation result to a sub-object for output query

### DIFF
--- a/examples/301-rest/workflow.yaml
+++ b/examples/301-rest/workflow.yaml
@@ -11,4 +11,4 @@ operations:
     tenant: {{azure.tenant}}
   request: azure-subscriptions-list.yaml
   output:
-    subscriptions: (value[].{ subscriptionId:subscriptionId, displayName:displayName })
+    subscriptions: (result.body.value[].{ subscriptionId:subscriptionId, displayName:displayName })

--- a/examples/302-gather-info/workflow.yaml
+++ b/examples/302-gather-info/workflow.yaml
@@ -8,7 +8,7 @@ operations:
     tenant: {{azure.tenant}}
   request: azure-tenants-list.yaml
   output:
-    tenants: (value[].{ tenantId:tenantId })
+    tenants: (result.body.value[].{ tenantId:tenantId })
 
 - message: (['Looking at tenant ', current.tenantId])
   values:
@@ -29,7 +29,7 @@ operations:
     request: graph-me-get.yaml
     output:
       current:
-        user: ({ "odata.type":"odata.type", objectId:objectId, displayName:displayName, userPrincipalName:userPrincipalName, otherMails:otherMails })
+        user: (result.body.{ "odata.type":"odata.type", objectId:objectId, displayName:displayName, userPrincipalName:userPrincipalName, otherMails:otherMails })
 
   - message: Listing Active Directory domains, see https://docs.microsoft.com/en-us/rest/api/graphrbac/domains/list
     values:
@@ -37,7 +37,7 @@ operations:
     request: graph-domains-list.yaml
     output:
       current:
-        domains: (value[].name)
+        domains: (result.body.value[].name)
 
   - message: Listing Microsoft Azure subscriptions, see https://docs.microsoft.com/en-us/rest/api/resources/subscriptions/list
     values:
@@ -45,7 +45,7 @@ operations:
     request: azure-subscriptions-list.yaml
     output:
       current:
-        subscriptions: (value[].{ subscriptionId:subscriptionId, displayName:displayName })
+        subscriptions: (result.body.value[].{ subscriptionId:subscriptionId, displayName:displayName })
 
 output: 
   details: (results)

--- a/examples/401-linux-agent-pool/workflow.yaml
+++ b/examples/401-linux-agent-pool/workflow.yaml
@@ -80,7 +80,7 @@ operations:
   - message: Waiting for deployment to complete...
     request: apis/azure/deployments/get.yaml
     output:
-      deploymentStatus: (@)
+      deploymentStatus: (result.body)
     repeat:
       condition: deploymentStatus.properties.provisioningState == 'Accepted' || deploymentStatus.properties.provisioningState == 'Running'
       delay: PT5S
@@ -108,7 +108,7 @@ operations:
     request: apis/azure/storage/listkeys.yaml
     output:
       storage:
-        key: (keys[0].value)
+        key: (result.body.keys[0].value)
 
   - message: Sending setup.sh
     values:
@@ -155,7 +155,7 @@ operations:
   - message: Waiting for deployment to complete...
     request: apis/azure/deployments/get.yaml
     output:
-      deploymentStatus: (@)
+      deploymentStatus: (result.body)
     repeat:
       condition: deploymentStatus.properties.provisioningState == 'Accepted' || deploymentStatus.properties.provisioningState == 'Running'
       delay: PT45S

--- a/examples/403-devops-pipelines/workflow.yaml
+++ b/examples/403-devops-pipelines/workflow.yaml
@@ -7,27 +7,27 @@ operations:
   request: apis/devops/distributedtask-queue-list.yaml
   output:
     devops:
-      queues: (value)
+      queues: (result.body.value)
 
 - message: Listing policy types
   request: apis/devops/policy-type-list.yaml
   output:
     devops:
       policy:
-        types: (value)
+        types: (result.body.value)
 
 - message: Listing policy configurations
   request: apis/devops/policy-configuration-list.yaml
   output:
     devops:
-      policies: (value)
+      policies: (result.body.value)
 
 - message: Listing groups
   request: apis/devops/graph-group-list.yaml
   output:
     devops:
       graph:
-        groups: (value)
+        groups: (result.body.value)
 
 {{# each devops.repository }}
 - message: Processing repository {{ name }}
@@ -38,7 +38,7 @@ operations:
   - message: Finding existing git repository
     request: apis/devops/git-repository-get.yaml
     output:
-      properties: (@)
+      properties: (result.body)
 
   output:
     devops:
@@ -60,19 +60,19 @@ operations:
     request: apis/devops/build-definition-query.yaml
     output:
       build:
-        id: "( value[?name=='{{ name }}' && path=='{{ path }}'] | [0].id )"
-        revision: "( value[?name=='{{ name }}' && path=='{{ path }}'] | [0].revision )"
+        id: "( result.body.value[?name=='{{ name }}' && path=='{{ path }}'] | [0].id )"
+        revision: "( result.body.value[?name=='{{ name }}' && path=='{{ path }}'] | [0].revision )"
 
   - message: Getting build definition details
     condition: (build.id != null)
     request: apis/devops/build-definition-get.yaml
     output:
-      existing: (@)
+      existing: (result.body)
 
   - message: Create or update build definition
     request: apis/devops/build-definition-save.yaml
     output:
-      properties: (@)
+      properties: (result.body)
 
   output:
     devops:
@@ -91,18 +91,18 @@ operations:
   operations:
   - message: Finding existing release definition
     request: apis/devops/release-definition-query.yaml
-    output: "( value[?name=='{{ name }}' && path=='{{ path }}'] | [0].{release:{id:id, revision:revision}} )"
+    output: "( result.body.value[?name=='{{ name }}' && path=='{{ path }}'] | [0].{release:{id:id, revision:revision}} )"
 
   - message: Getting release definition details
     condition: (release.id != null)
     request: apis/devops/release-definition-get.yaml
     output:
-      existing: (@)
+      existing: (result.body)
 
   - message: Create or update release definition
     request: apis/devops/release-definition-save.yaml
     output:
-      properties: (@)
+      properties: (result.body)
 
   output:
     devops:
@@ -118,18 +118,12 @@ operations:
 
   operations:
   - template: branch-policy-assign-properties.yaml
-    write: branch-policy-assign-properties.yaml
-
-  - template: branch-policy-assign-properties.yaml
-    output: (@)
-
-  - template: branch-policy-build-list.yaml
-    write: branch-policy-build-list.yaml
+    output: (result)
 
   - message: Building branch policy list
     template: branch-policy-build-list.yaml
     output: 
-      foreach: (@)
+      foreach: (result)
 
   - message: Saving branch policies
     condition: (length(foreach || `[]`) != `0` )
@@ -139,7 +133,7 @@ operations:
         policy: ( foreach[0] )
       request: apis/devops/policy-configuration-save.yaml
       output:
-        policy: ( to_object( [[ to_string(id), {properties:@} ]] ) )
+        policy: ( result.body.to_object( [[ to_string(id), {properties:@} ]] ) )
     output:
       foreach: ( foreach[1:] )
       policy: ( policy )

--- a/src/Microsoft.Atlas.CommandLine/JsonClient/JsonHttpClient.cs
+++ b/src/Microsoft.Atlas.CommandLine/JsonClient/JsonHttpClient.cs
@@ -99,7 +99,10 @@ namespace Microsoft.Atlas.CommandLine.JsonClient
 
             var jsonResponse = new JsonResponse
             {
-                status = response.StatusCode
+                status = (int)response.StatusCode,
+                headers = response.Headers
+                    .Concat(response?.Content?.Headers ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())
+                    .ToDictionary(kv => (object)kv.Key, kv => (object)kv.Value.ToList<object>()),
             };
 
             // var responseBody = await response.Content.ReadAsStringAsync();
@@ -112,7 +115,7 @@ namespace Microsoft.Atlas.CommandLine.JsonClient
             // Information is added to secret tracker as soon as possible
             if (!string.IsNullOrEmpty(jsonRequest.secret) && jsonResponse.body != null)
             {
-                var searchResult = _jmesPath.Search(jsonRequest.secret, jsonResponse.body);
+                var searchResult = _jmesPath.Search(jsonRequest.secret, new { result = jsonResponse });
 
                 var secrets = searchResult as IEnumerable<object>;
                 if (secrets != null)

--- a/src/Microsoft.Atlas.CommandLine/JsonClient/JsonResponse.cs
+++ b/src/Microsoft.Atlas.CommandLine/JsonClient/JsonResponse.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System.Collections.Generic;
 using System.Net;
 
 #pragma warning disable IDE1006 // Naming Styles
@@ -12,8 +13,10 @@ namespace Microsoft.Atlas.CommandLine.JsonClient
 {
     public class JsonResponse
     {
-        public HttpStatusCode status { get; set; }
+        public int status { get; set; }
 
         public object body { get; set; }
+
+        public IDictionary<object, object> headers { get; internal set; }
     }
 }

--- a/src/Microsoft.Atlas.CommandLine/Models/Workflow/Model.cs
+++ b/src/Microsoft.Atlas.CommandLine/Models/Workflow/Model.cs
@@ -52,6 +52,13 @@ namespace Microsoft.Atlas.CommandLine.Models.Workflow
             }
         }
 
+        public class Response
+        {
+            public int status { get; set; }
+            public IDictionary<object, object> headers { get; set; }
+            public object body { get; set; }
+        }
+
         public class Repeat
         {
             public string condition { get; set; }

--- a/test/Microsoft.Atlas.CommandLine.Tests/RequestOperationTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/RequestOperationTests.cs
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.Atlas.CommandLine.Secrets;
+using Microsoft.Atlas.CommandLine.Tests.Stubs;
+using Microsoft.Atlas.CommandLine.Tests.Utilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Atlas.CommandLine.Tests
+{
+    [TestClass]
+    public class RequestOperationTests : ServiceContextTestsBase<RequestOperationTests.ServiceContext>
+    {
+        [TestMethod]
+        public void ResponseBodyMayBeQueried()
+        {
+            var stubBlueprints = Yaml<StubBlueprintManager>(@"
+                Blueprints:
+                  the-test:
+                    Files:
+                      workflow.yaml: |
+                        operations:
+                        - request: request.yaml
+                          output:
+                            x: (result.body.color)
+                            y: (result.body.id)
+                      request.yaml: |
+                        method: GET
+                        url: https://localhost/
+            ");
+
+            var stubHttpClients = Yaml<StubHttpClientHandlerFactory>(@"
+                Responses:
+                  https://localhost/:
+                    GET:
+                      status: 200
+                      body:
+                        id: 4
+                        color: green
+            ");
+
+            InitializeServices(stubBlueprints, stubHttpClients);
+
+            var result = Services.App.Execute("deploy", "the-test");
+
+            Assert.AreEqual(0, result);
+
+            Console.AssertContainsInOrder("x: green", "y:", "4");
+        }
+
+        [TestMethod]
+        public void ResponseMayBeMergedWithWorkingMemory()
+        {
+            var stubBlueprints = Yaml<StubBlueprintManager>(@"
+                Blueprints:
+                  the-test:
+                    Files:
+                      workflow.yaml: |
+                        operations:
+                        - output:
+                            b: [three,four]
+                        - values:
+                            a: [one,two]
+                          request: request.yaml
+                          output:
+                            d: ([a,b,result.body,c][])
+                      request.yaml: |
+                        method: GET
+                        url: https://localhost/
+            ");
+
+            var stubHttpClients = Yaml<StubHttpClientHandlerFactory>(@"
+                Responses:
+                  https://localhost/:
+                    GET:
+                      status: 200
+                      body:
+                        c: [five,six]
+            ");
+
+            InitializeServices(stubBlueprints, stubHttpClients);
+
+            var result = Services.App.Execute("deploy", "the-test");
+
+            Assert.AreEqual(0, result);
+
+            Console.AssertContainsInOrder("d:", "one", "two", "three", "four", "five", "six");
+        }
+
+        [TestMethod]
+        public void StatusAndHeadersAreAvailable()
+        {
+            var stubBlueprints = Yaml<StubBlueprintManager>(@"
+                Blueprints:
+                  the-test:
+                    Files:
+                      workflow.yaml: |
+                        operations:
+                        - request: request.yaml
+                          output:
+                            x: (result.status)
+                            y: (result.headers.""Content-Type""[0])
+                            z: (result.headers.""Content-Length""[0])
+                      request.yaml: |
+                        method: GET
+                        url: https://localhost/
+            ");
+
+            var stubHttpClients = Yaml<StubHttpClientHandlerFactory>(@"
+                Responses:
+                  https://localhost/:
+                    GET:
+                      status: 200
+                      headers:
+                        Content-Type: [text/plain]
+                        Content-Length: [12]
+                      body: Hello world!
+            ");
+
+            InitializeServices(stubBlueprints, stubHttpClients);
+
+            var result = Services.App.Execute("deploy", "the-test");
+
+            Assert.AreEqual(0, result);
+
+            Console.AssertContainsInOrder("x:", "200", "y:", "text/plain", "z:", "12");
+        }
+
+        public class ServiceContext : ServiceContextBase
+        {
+            public CommandLineApplicationServices App { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.Atlas.CommandLine.Tests/Stubs/StubConsole.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Stubs/StubConsole.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using System;
 using System.IO;
 using Microsoft.Atlas.CommandLine.ConsoleOutput;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -28,7 +29,7 @@ namespace Microsoft.Atlas.CommandLine.Tests.Stubs
                 var segmentIndex = output.IndexOf(segment, startIndex);
                 if (segmentIndex < 0)
                 {
-                    Assert.Fail($"Output did not contain {segment}");
+                    Assert.Fail($"Output did not contain {segment}{Environment.NewLine}{output}");
                 }
 
                 startIndex = segmentIndex + segment.Length;


### PR DESCRIPTION
* enables a request or template operation to query from existing
working memory as well as the operation's result data

* adds response status and headers as `result.status and result.headers.*[*]`

* request.secret also uses result as starting point, so response
headers may be redacted

Fixes #50