### PR TITLE
Fixing a bug in listkeys.yaml template files

### DIFF
--- a/examples/401-linux-agent-pool/apis/azure/storage/listkeys.yaml
+++ b/examples/401-linux-agent-pool/apis/azure/storage/listkeys.yaml
@@ -2,9 +2,9 @@
 # https://docs.microsoft.com/en-us/rest/api/storagerp/srp_json_get_storage_account_keys
 
 method: POST
-url: https://management.azure.com/subscriptions/{{azure.subscription}}/resourceGroups/{{azure.resourceGroupName}}/providers/Microsoft.Storage/storageAccounts/{{storage.account}}/listKeys?api-version=2018-03-01-preview
+url: https://management.azure.com/subscriptions/{{ azure.subscription }}/resourceGroups/{{ azure.resourceGroupName }}/providers/Microsoft.Storage/storageAccounts/{{ storage.account }}/listKeys?api-version=2018-03-01-preview
 auth:
-  tenant: {{azure.tenant}}
+  tenant: {{ azure.tenant }}
   resource: https://management.core.windows.net/
   client: 04b07795-8ddb-461a-bbee-02f9e1bf7b46 # Azure CLI
 secret: result.body.keys[*].value

--- a/examples/401-linux-agent-pool/apis/azure/storage/listkeys.yaml
+++ b/examples/401-linux-agent-pool/apis/azure/storage/listkeys.yaml
@@ -7,4 +7,4 @@ auth:
   tenant: {{azure.tenant}}
   resource: https://management.core.windows.net/
   client: 04b07795-8ddb-461a-bbee-02f9e1bf7b46 # Azure CLI
-secret: keys[*].value
+secret: result.body.keys[*].value

--- a/examples/402-cdn-with-storage-account/apis/azure/storage/listkeys.yaml
+++ b/examples/402-cdn-with-storage-account/apis/azure/storage/listkeys.yaml
@@ -7,4 +7,4 @@ auth:
   tenant: {{azure.tenant}}
   resource: https://management.core.windows.net/
   client: 04b07795-8ddb-461a-bbee-02f9e1bf7b46 # Azure CLI
-secret: keys[*].value
+secret: result.body.keys[*].value


### PR DESCRIPTION
* `secret:` needs `result.body.` in the jmespath to find the secrets