### PR TITLE
Pipeline task property for Azure RM connection info

### DIFF
--- a/src/Microsoft.Atlas.CommandLine/Commands/AccountCommands.cs
+++ b/src/Microsoft.Atlas.CommandLine/Commands/AccountCommands.cs
@@ -130,6 +130,8 @@ namespace Microsoft.Atlas.CommandLine.Commands
                 appid = entry.appid,
                 secret = string.IsNullOrEmpty(entry.secret) ? entry.secret : "***",
                 token = string.IsNullOrEmpty(entry.token) ? entry.token : "***",
+                username = entry.username,
+                password = string.IsNullOrEmpty(entry.token) ? entry.password : "***",
             };
         }
     }

--- a/src/Microsoft.Atlas.CommandLine/OAuth2/TokenProvider.cs
+++ b/src/Microsoft.Atlas.CommandLine/OAuth2/TokenProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Atlas.CommandLine.OAuth2
 
             // https://login.microsoftonline.com
             // https://login.windows.net
-            var authority = $"https://login.windows.net/{tenant ?? "common"}";
+            var authority = $"https://login.windows.net/{ tenant ?? "common" }";
 
             AccountEntry account = null;
             if (account == null)
@@ -64,10 +64,13 @@ namespace Microsoft.Atlas.CommandLine.OAuth2
 
             if (account != null)
             {
-                // TODO: split apart the idea of a bearer auth accesstoken and a basic auth PAT
                 if (!string.IsNullOrEmpty(account.token))
                 {
-                    var basic = $":{account.token}";
+                    return new AuthenticationHeaderValue("Bearer", account.token);
+                }
+                else if (!string.IsNullOrEmpty(account.password))
+                {
+                    var basic = $"{account.username}:{account.password}";
                     return new AuthenticationHeaderValue("Basic", Convert.ToBase64String(Encoding.ASCII.GetBytes(basic)));
                 }
                 else if (!string.IsNullOrEmpty(account.appid))

--- a/src/Microsoft.Atlas.CommandLine/OAuth2/TokenProvider.cs
+++ b/src/Microsoft.Atlas.CommandLine/OAuth2/TokenProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Atlas.CommandLine.OAuth2
 
             // https://login.microsoftonline.com
             // https://login.windows.net
-            var authority = $"https://login.windows.net/{ tenant ?? "common" }";
+            var authority = $"https://login.windows.net/{tenant ?? "common"}";
 
             AccountEntry account = null;
             if (account == null)

--- a/src/Tasks/AtlasV0/src/index.ts
+++ b/src/Tasks/AtlasV0/src/index.ts
@@ -1,18 +1,32 @@
 import tl = require('vsts-task-lib/task');
 import trm = require('vsts-task-lib/toolrunner');
 import path = require("path");
+import inputs = require('./inputs');
 
 async function run() {
     try {
-        var command = tl.getInput("command", true);
-        var args = tl.getInput("arguments", false);
-
+        var parameters = await new inputs.TaskParameters().getParameters();
+        
         var atlasPath = tl.which("atlas", true);
+
+        if (!!parameters.azureSubscriptionEndpoint) {
+            
+            var accountAdd = tl.tool(atlasPath).arg([ 
+                'account', 'add',
+                '--name', parameters.azureSubscriptionEndpoint.connectedService,
+                '--authority', parameters.azureSubscriptionEndpoint.environmentAuthorityUrl + parameters.azureSubscriptionEndpoint.tenantId,
+                '--resource', parameters.azureSubscriptionEndpoint.endpointUrl,
+                '--appid', parameters.azureSubscriptionEndpoint.servicePrincipalId,
+                '--secret', parameters.azureSubscriptionEndpoint.servicePrincipalKey
+            ]);
+
+            await accountAdd.exec();
+        }
         
         var atlas = tl.tool(atlasPath)
-            .arg(command);
+            .line(parameters.command);
 
-        atlas.line(args);
+        atlas.line(parameters.arguments);
     
         return await atlas.exec();
     }

--- a/src/Tasks/AtlasV0/src/inputs.ts
+++ b/src/Tasks/AtlasV0/src/inputs.ts
@@ -1,0 +1,92 @@
+import tl = require("vsts-task-lib/task");
+import path = require("path");
+import fs = require("fs");
+
+const certFilePath: string = path.join(tl.getVariable('Agent.TempDirectory'), 'spnCert.pem');
+
+export class ConnectedServiceAzureRM {
+
+    connectedService: string;
+    subscriptionId: string;
+    subscriptionName: string;
+    servicePrincipalId: string;
+    environmentAuthorityUrl: string;
+    tenantId: string;
+    endpointUrl: string;
+    environment: string;
+    authorizationScheme: string;
+    msiClientId: string;
+    activeDirectoryServiceEndpointResourceId: string;
+    azureKeyVaultServiceEndpointResourceId: string;
+    azureKeyVaultDnsSuffix: string;
+    authenticationType: string;
+    servicePrincipalCertificate: string;
+    servicePrincipalCertificatePath: string;
+    servicePrincipalKey: string;
+
+    constructor(connectedService: string) {
+        this.connectedService = connectedService;
+    }
+
+    public async getParameters() : Promise<ConnectedServiceAzureRM> {
+        this.subscriptionId = tl.getEndpointDataParameter(this.connectedService, 'subscriptionid', true);
+        this.subscriptionName = tl.getEndpointDataParameter(this.connectedService, 'subscriptionname', true);
+        this.servicePrincipalId = tl.getEndpointAuthorizationParameter(this.connectedService, 'serviceprincipalid', true);
+        this.environmentAuthorityUrl = tl.getEndpointDataParameter(this.connectedService, 'environmentAuthorityUrl', true);
+        this.tenantId = tl.getEndpointAuthorizationParameter(this.connectedService, 'tenantid', false);
+        
+        this.endpointUrl = tl.getEndpointUrl(this.connectedService, true);
+        this.environment = tl.getEndpointDataParameter(this.connectedService, 'environment', true);
+        this.authorizationScheme = tl.getEndpointAuthorizationScheme(this.connectedService, true);
+
+        this.msiClientId = tl.getEndpointDataParameter(this.connectedService, 'msiclientId', true);
+        this.activeDirectoryServiceEndpointResourceId = tl.getEndpointDataParameter(this.connectedService, 'activeDirectoryServiceEndpointResourceId', true);
+        this.azureKeyVaultServiceEndpointResourceId = tl.getEndpointDataParameter(this.connectedService, 'AzureKeyVaultServiceEndpointResourceId', true);
+        this.azureKeyVaultDnsSuffix = tl.getEndpointDataParameter(this.connectedService, 'AzureKeyVaultDnsSuffix', true);
+
+        this.authenticationType = tl.getEndpointAuthorizationParameter(this.connectedService, 'authenticationType', true);
+
+        tl.debug(JSON.stringify(this));
+
+        let isServicePrincipalAuthenticationScheme = !this.authorizationScheme || this.authorizationScheme.toLowerCase() == 'serviceprincipal';
+            if (isServicePrincipalAuthenticationScheme) {
+                if(this.authenticationType && this.authenticationType == 'servicePrincipalCertificate') {
+                    tl.debug('certificate spn endpoint');
+                    this.servicePrincipalCertificate = tl.getEndpointAuthorizationParameter(this.connectedService, 'servicePrincipalCertificate', false);
+                    this.servicePrincipalCertificatePath = certFilePath;
+                    fs.writeFileSync(this.servicePrincipalCertificatePath, this.servicePrincipalCertificate);
+                }
+                else {
+                    tl.debug('credentials spn endpoint');
+                    this.servicePrincipalKey = tl.getEndpointAuthorizationParameter(this.connectedService, 'serviceprincipalkey', false);
+                }
+            }
+
+        return this;
+    }
+}
+
+export class TaskParameters {
+
+    public command: string;
+    public arguments: string;
+    public azureSubscriptionEndpoint: ConnectedServiceAzureRM;
+
+    public async getParameters() : Promise<TaskParameters> 
+    {
+        try {
+            this.command = tl.getInput("command", true);
+            this.arguments = tl.getInput("arguments", false);
+
+            var connectedService = tl.getInput("azureSubscriptionEndpoint", true);
+
+            this.azureSubscriptionEndpoint = await new ConnectedServiceAzureRM(connectedService).getParameters();
+
+            tl.getInput("deploymentGroupEndpoint", false);
+
+            return this;
+        } catch (error) {
+            throw new Error("Get parameters failed " + error.message);
+        }
+    }    
+}

--- a/src/Tasks/AtlasV0/task.json
+++ b/src/Tasks/AtlasV0/task.json
@@ -36,27 +36,41 @@
         "azureSubscription"
       ],
       "type": "connectedService:AzureRM",
-      "label": "Azure Connection",
-      "helpMarkDown": "Select an Azure service endpoint.",
-      "defaultValue": "",
-      "required": false,
-      "groupName": "commands"
+      "label": "Azure subscription",
+      "helpMarkDown": "Credentials to use for Azure Resource Manager operations.",
+      "required": false
     },
     {
       "name": "command",
-      "type": "string",
-      "label": "command",
+      "type": "pickList",
+      "label": "Command",
       "defaultValue": "deploy",
       "required": true,
-      "helpMarkDown": "Atlas command to execute"
+      "options": {
+        "account add": "account add",
+        "account clear": "account clear",
+        "account show": "account show",
+        "deploy": "deploy",
+        "generate": "generate"
+      },
+      "helpMarkDown": "Select an Atlas command",
+      "groupName": "commands",
+      "properties": {
+        "EditableOptions": "True"
+      }
     },
     {
       "name": "arguments",
-      "type": "string",
-      "label": "arguments",
+      "type": "multiLine",
+      "properties": {
+          "resizable": "true",
+          "rows": "2"
+      },
+      "label": "Arguments",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Additional command line arguments"
+      "helpMarkDown": "Additional command line arguments",
+      "groupName": "commands"
     }
   ],
   "execution": {


### PR DESCRIPTION
Selecting an Azure connection from the pipeline task makes the service principal's credentials available to the workflow as it is executing.

Only works with client-secret credential type at the moment. Will need to file more issues for the other credential types.