### PR TITLE
Change program path in launch.json from netcoreapp2.0 to netcoreapp2.1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/Microsoft.Atlas.CommandLine/bin/Debug/netcoreapp2.0/atlas.dll",
+            "program": "${workspaceFolder}/src/Microsoft.Atlas.CommandLine/bin/Debug/netcoreapp2.1/atlas.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Microsoft.Atlas.CommandLine",
             "console": "internalConsole",


### PR DESCRIPTION
README already suggests the use of .net Core >= 2.1.
I think the included launch.json should reflect this, so that you don't get the error that binary does not exist, when debugging this project for the first time. 
Especially since the TargetFramework is "netcoreapp2.1".

![13-10-2018 23-38-28](https://user-images.githubusercontent.com/1630038/46910278-e6fd8b80-cf41-11e8-8819-033e5a54e7df.png)
