### PR TITLE
Fix bug with https blueprint provider

### DIFF
--- a/src/Microsoft.Atlas.CommandLine/Templates/FileSystems/ProbingFileSystem.cs
+++ b/src/Microsoft.Atlas.CommandLine/Templates/FileSystems/ProbingFileSystem.cs
@@ -38,25 +38,24 @@ namespace Microsoft.Atlas.CommandLine.Templates.FileSystems
 
         private IEnumerable<string> WithoutPartialsFolder(string filePath)
         {
-            yield return filePath;
-
-            const string partials = "partials/";
-            if (filePath.StartsWith(partials, StringComparison.Ordinal))
+            const string partialsFolder = "partials/";
+            if (filePath.StartsWith(partialsFolder, StringComparison.Ordinal))
             {
-                yield return filePath.Substring(partials.Length);
+                yield return filePath.Substring(partialsFolder.Length);
             }
+
+            yield return filePath;
         }
 
         private IEnumerable<string> WithoutExtension(string filePath)
         {
-            yield return filePath;
-
-            if (Path.GetExtension(filePath) == ".hbs")
+            const string hbsExtension = "hbs";
+            if (filePath.EndsWith(hbsExtension))
             {
-                yield return Path.Combine(
-                    Path.GetDirectoryName(filePath),
-                    Path.GetFileNameWithoutExtension(filePath));
+                yield return filePath.Substring(0, filePath.Length - hbsExtension.Length);
             }
+
+            yield return filePath;
         }
     }
 }

--- a/src/Microsoft.Atlas.CommandLine/Templates/FileSystems/ProbingFileSystem.cs
+++ b/src/Microsoft.Atlas.CommandLine/Templates/FileSystems/ProbingFileSystem.cs
@@ -38,10 +38,10 @@ namespace Microsoft.Atlas.CommandLine.Templates.FileSystems
 
         private IEnumerable<string> WithoutPartialsFolder(string filePath)
         {
-            const string partialsFolder = "partials/";
-            if (filePath.StartsWith(partialsFolder, StringComparison.Ordinal))
+            const string PartialsFolder = "partials/";
+            if (filePath.StartsWith(PartialsFolder, StringComparison.Ordinal))
             {
-                yield return filePath.Substring(partialsFolder.Length);
+                yield return filePath.Substring(PartialsFolder.Length);
             }
 
             yield return filePath;
@@ -49,10 +49,10 @@ namespace Microsoft.Atlas.CommandLine.Templates.FileSystems
 
         private IEnumerable<string> WithoutExtension(string filePath)
         {
-            const string hbsExtension = "hbs";
-            if (filePath.EndsWith(hbsExtension))
+            const string HbsExtension = ".hbs";
+            if (filePath.EndsWith(HbsExtension))
             {
-                yield return filePath.Substring(0, filePath.Length - hbsExtension.Length);
+                yield return filePath.Substring(0, filePath.Length - HbsExtension.Length);
             }
 
             yield return filePath;


### PR DESCRIPTION
* System.IO.Path methods would encode `/` characters
* String methods do not
* Also re-order to try shorter paths first, to reduce
the number of NotFound responses