### PR TITLE
Fixing bug loading workflows

### DIFF
--- a/src/Microsoft.Atlas.CommandLine/Blueprints/BlueprintManager.cs
+++ b/src/Microsoft.Atlas.CommandLine/Blueprints/BlueprintManager.cs
@@ -44,10 +44,14 @@ namespace Microsoft.Atlas.CommandLine.Blueprints
 
                 var codeBlocks = readmeDoc.OfType<FencedCodeBlock>();
                 var yamlBlocks = codeBlocks.Where(cb => string.Equals(cb.Info, "yaml", StringComparison.Ordinal));
-                var yamlLines = yamlBlocks.SelectMany(yaml => yaml.Lines.Lines);
-                var yamlText = yamlLines.Aggregate(string.Empty, (a, b) => $"{a}{b}{Environment.NewLine}");
 
-                blueprintInfo = _yamlSerializers.YamlDeserializer.Deserialize<WorkflowInfoDocument>(yamlText);
+                if (yamlBlocks.Any())
+                {
+                    var yamlLines = yamlBlocks.SelectMany(yaml => yaml.Lines.Lines);
+                    var yamlText = yamlLines.Aggregate(string.Empty, (a, b) => $"{a}{b}{Environment.NewLine}");
+
+                    blueprintInfo = _yamlSerializers.YamlDeserializer.Deserialize<WorkflowInfoDocument>(yamlText);
+                }
             }
 
             var blueprintPackage = blueprintPackageCore;

--- a/test/Microsoft.Atlas.CommandLine.Tests/WorkflowCommandsTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/WorkflowCommandsTests.cs
@@ -297,5 +297,82 @@ Responses:
 
             Assert.IsTrue(error.Message.Contains("interactive"), "Exception message includes 'interactive'");
         }
+
+        [TestMethod]
+        public async Task WorkflowCanRunWithOnlyHttpsWorkflowYamlFile()
+        {
+            var stubRequests = Yaml<StubHttpClientHandlerFactory>(@"
+Responses:
+    https://localhost/just/workflow.yaml: 
+        GET:
+            status: 200
+            body: |
+                operations:
+                - message: Just a workflow file
+");
+
+            InitializeServices(stubRequests);
+
+            Services.App.Execute("deploy", "https://localhost/just/workflow.yaml");
+
+            Console.AssertContainsInOrder("Just a workflow file");
+        }
+
+        [TestMethod]
+        public async Task WorkflowCanContainReadmeWithNoYaml()
+        {
+            var stubRequests = Yaml<StubHttpClientHandlerFactory>(@"
+Responses:
+    https://localhost/minimal/workflow.yaml: 
+        GET:
+            status: 200
+            body: |
+                operations:
+                - message: Just a workflow file
+    https://localhost/minimal/readme.md: 
+        GET:
+            status: 200
+            body: |
+                # Minimal
+
+                and has no yaml code blocks
+
+
+");
+
+            InitializeServices(stubRequests);
+
+            Services.App.Execute("deploy", "https://localhost/minimal/workflow.yaml");
+
+            Console.AssertContainsInOrder("Just a workflow file");
+        }
+
+        [TestMethod]
+        public async Task WorkflowCanContainMinimalReadmeInfo()
+        {
+            var stubRequests = Yaml<StubHttpClientHandlerFactory>(@"
+Responses:
+    https://localhost/minimal/workflow.yaml: 
+        GET:
+            status: 200
+            body: |
+                operations:
+                - message: Just a workflow file
+    https://localhost/minimal/readme.md: 
+        GET:
+            status: 200
+            body: |
+                ``` yaml
+                info:
+                  title: minimal
+                ```
+");
+
+            InitializeServices(stubRequests);
+
+            Services.App.Execute("deploy", "https://localhost/minimal/workflow.yaml");
+
+            Console.AssertContainsInOrder("Just a workflow file");
+        }
     }
 }


### PR DESCRIPTION
If there was a readme.md file with no yaml code blocks
then the workflow's info object ended up being null