### PR TITLE
Build docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+
+**/obj
+**/bin
+
+.vs
+.vscode
+examples

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -8,7 +8,7 @@ COPY build/. ./build/
 COPY src/Microsoft.Atlas.CommandLine/*.csproj ./src/Microsoft.Atlas.CommandLine/
 COPY src/Microsoft.Atlas.CommandLine.Chocolatey/*.csproj ./src/Microsoft.Atlas.CommandLine.Chocolatey/
 COPY test/Microsoft.Atlas.CommandLine.Tests/*.csproj ./test/Microsoft.Atlas.CommandLine.Tests/
-RUN dotnet restore --force
+RUN dotnet restore
 COPY src/. ./src/
 COPY test/. ./test/
 COPY docs/. ./docs/
@@ -21,10 +21,23 @@ ENTRYPOINT ["dotnet", "test", "--logger:trx", "-c", "Release"]
 
 FROM restore as publish
 WORKDIR /app
-RUN dotnet publish src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj -c Release -o /out/atlas
-RUN dotnet pack    src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj -c Release -o /out/tools
-RUN dotnet msbuild src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj /t:Restore,CreateTarball /p:RuntimeIdentifier=linux-x64 /p:TargetFramework=netcoreapp2.1 /p:Configuration=Release /p:ArchiveDir=/out/downloads
-RUN dotnet msbuild src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj /t:Restore,CreateZip     /p:RuntimeIdentifier=win10-x64 /p:TargetFramework=netcoreapp2.1 /p:Configuration=Release /p:ArchiveDir=/out/downloads
+ARG BUILD_BUILDID
+ARG BUILD_REPOSITORY_URI
+ARG BUILD_SOURCEBRANCHNAME
+ARG BUILD_SOURCEVERSION
+RUN \
+    BUILD_BUILDID=${BUILD_BUILDID} \
+    BUILD_REPOSITORY_URI=${BUILD_REPOSITORY_URI} \
+    BUILD_SOURCEBRANCHNAME=${BUILD_SOURCEBRANCHNAME} \
+    BUILD_SOURCEVERSION=${BUILD_SOURCEVERSION} \
+    dotnet publish src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj \
+        -c Release -o /out/atlas && \
+    dotnet pack    src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj \
+        -c Release -o /out/tools && \
+    dotnet msbuild src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj \
+        /t:Restore,CreateTarball /p:RuntimeIdentifier=linux-x64 /p:TargetFramework=netcoreapp2.1 /p:Configuration=Release /p:ArchiveDir=/out/downloads && \
+    dotnet msbuild src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj \
+        /t:Restore,CreateZip /p:RuntimeIdentifier=win10-x64 /p:TargetFramework=netcoreapp2.1 /p:Configuration=Release /p:ArchiveDir=/out/downloads
 
 FROM microsoft/dotnet:2.1-runtime AS runtime
 WORKDIR /app

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -12,16 +12,21 @@ RUN dotnet restore --force
 COPY src/. ./src/
 COPY test/. ./test/
 COPY docs/. ./docs/
-
-FROM restore as publish
-WORKDIR /app
-RUN dotnet publish src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj -c Release -o /out
-
-FROM microsoft/dotnet:2.1-runtime AS runtime
-WORKDIR /app
-COPY --from=publish /out ./
-ENTRYPOINT ["dotnet", "atlas.dll"]
+COPY LICENSE ./
+COPY ThirdPartyNotice.txt ./
 
 FROM restore AS test
 WORKDIR /app/test/Microsoft.Atlas.CommandLine.Tests
 ENTRYPOINT ["dotnet", "test", "--logger:trx", "-c", "Release"]
+
+FROM restore as publish
+WORKDIR /app
+RUN dotnet publish src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj -c Release -o /out/atlas
+RUN dotnet pack    src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj -c Release -o /out/tools
+RUN dotnet msbuild src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj /t:Restore,CreateTarball /p:RuntimeIdentifier=linux-x64 /p:TargetFramework=netcoreapp2.1 /p:Configuration=Release /p:ArchiveDir=/out/downloads
+RUN dotnet msbuild src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj /t:Restore,CreateZip     /p:RuntimeIdentifier=win10-x64 /p:TargetFramework=netcoreapp2.1 /p:Configuration=Release /p:ArchiveDir=/out/downloads
+
+FROM microsoft/dotnet:2.1-runtime AS runtime
+WORKDIR /app
+COPY --from=publish /out/atlas ./
+ENTRYPOINT ["dotnet", "atlas.dll"]

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,0 +1,27 @@
+FROM microsoft/dotnet:2.1-sdk AS restore
+WORKDIR /app
+COPY *.sln ./
+COPY .editorconfig ./
+COPY Directory.Build.props ./
+COPY Directory.Build.targets ./
+COPY build/. ./build/
+COPY src/Microsoft.Atlas.CommandLine/*.csproj ./src/Microsoft.Atlas.CommandLine/
+COPY src/Microsoft.Atlas.CommandLine.Chocolatey/*.csproj ./src/Microsoft.Atlas.CommandLine.Chocolatey/
+COPY test/Microsoft.Atlas.CommandLine.Tests/*.csproj ./test/Microsoft.Atlas.CommandLine.Tests/
+RUN dotnet restore --force
+COPY src/. ./src/
+COPY test/. ./test/
+COPY docs/. ./docs/
+
+FROM restore as publish
+WORKDIR /app
+RUN dotnet publish src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj -c Release -o /out
+
+FROM microsoft/dotnet:2.1-runtime AS runtime
+WORKDIR /app
+COPY --from=publish /out ./
+ENTRYPOINT ["dotnet", "atlas.dll"]
+
+FROM restore AS test
+WORKDIR /app/test/Microsoft.Atlas.CommandLine.Tests
+ENTRYPOINT ["dotnet", "test", "--logger:trx", "-c", "Release"]

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -1,28 +1,25 @@
 steps:
 
 - script: |
-    docker build -f Dockerfile.cli --target runtime --tag atlasprivate.azurecr.io/atlas-cli:0.1.$(Build.BuildId) .
-    docker build -f Dockerfile.cli --target test --tag atlasprivate.azurecr.io/atlas-cli:test .
+    testContainerName=test-$(Build.BuildId)
+    publishContainerName=publish-$(Build.BuildId)
 
-    testContainerName=test-$(Agent.Id)-$(System.DefinitionId)-$(Build.BuildId)
-    docker run --name ${testContainerName} atlasprivate.azurecr.io/atlas-cli:test
+    docker build -f Dockerfile.cli --target test --tag atlas-cli-test:0.1.$(Build.BuildId) .
+    docker run --name ${testContainerName} atlas-cli-test:0.1.$(Build.BuildId)
     docker cp ${testContainerName}:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults/. $(Build.ArtifactStagingDirectory)/TestResults
     docker rm ${testContainerName}
+
+    docker build -f Dockerfile.cli --target publish --tag atlas-cli-publish:0.1.$(Build.BuildId) .
+    docker create --name ${publishContainerName} atlas-cli-publish:0.1.$(Build.BuildId)
+    docker cp ${publishContainerName}:/out/. $(Build.ArtifactStagingDirectory)
+    docker rm ${publishContainerName}
+
+    docker build -f Dockerfile.cli --target runtime --tag atlasprivate.azurecr.io/atlas-cli:0.1.$(Build.BuildId) .
 
 - task: PublishTestResults@2
   inputs:
     testRunner: VSTest
     testResultsFiles: '$(Build.ArtifactStagingDirectory)/TestResults/*.trx'
-
-- task: Docker@1
-  displayName: 'Push atlas-cli to atlasprivate.azurecr.io'
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-  inputs:
-    azureSubscriptionEndpoint: 'atlas-downloads'
-    azureContainerRegistry: atlasprivate.azurecr.io
-    command: 'Push an image'
-    imageName: 'atlas-cli:0.1.$(Build.BuildId)'
-    includeSourceTags: true
 
 # Node Tool Installer
 # Finds or Downloads and caches specified version spec of Node and adds it to the PATH.
@@ -51,57 +48,6 @@ steps:
   inputs:
     governanceProduct: '70f3e0d8-e9ab-e811-bce7-00155d7fb5a6'  
 
-- task: DotNetCoreCLI@2
-  displayName: dotnet build
-
-# - task: DotNetCoreCLI@2
-#   displayName: dotnet test
-#   inputs:
-#     command: test
-#     projects: 'test/**/*.csproj'
-
-- task: DotNetCoreCLI@2
-  displayName: dotnet publish
-  inputs:
-    command: publish
-    publishWebProjects: false
-    projects: 'src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj'
-    arguments: '-o $(Build.ArtifactStagingDirectory)/atlas'
-    zipAfterPublish: false
-    modifyOutputPath: false
-
-- task: DotNetCoreCLI@2
-  displayName: dotnet pack
-  inputs:
-    command: pack
-    packagesToPack: 'src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj'
-    configuration: Release
-    packDirectory: '$(Build.ArtifactStagingDirectory)/tools'
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet tarball'
-  inputs:
-    command: custom
-    projects: src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj
-    custom: msbuild
-    arguments: '/t:Restore,CreateTarball /p:RuntimeIdentifier=linux-x64 /p:TargetFramework=netcoreapp2.1 /p:Configuration=Release /p:ArchiveDir=$(Build.ArtifactStagingDirectory)/downloads'
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet zip'
-  inputs:
-    command: custom
-    projects: src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj
-    custom: msbuild
-    arguments: '/t:Restore,CreateZip /p:RuntimeIdentifier=win10-x64 /p:TargetFramework=netcoreapp2.1 /p:Configuration=Release /p:ArchiveDir=$(Build.ArtifactStagingDirectory)/downloads'
-
-- task: DotNetCoreCLI@2
-  displayName: dotnet pack chocolatey
-  inputs:
-    command: pack
-    packagesToPack: 'src/Microsoft.Atlas.CommandLine.Chocolatey/Microsoft.Atlas.CommandLine.Chocolatey.csproj'
-    configuration: Release
-    packDirectory: '$(Build.ArtifactStagingDirectory)/chocolatey'
-
 - task: CopyFiles@2
   displayName: 'copy examples to $(Build.ArtifactStagingDirectory)'
   inputs:
@@ -126,8 +72,20 @@ steps:
     sed -ri 's/"version": "0.1.[0-9]+"/"version": "0.1.$(Build.BuildId)"/' vss-extension.json
     tfx extension create --manifest-globs vss-extension.json --output-path $(Build.ArtifactStagingDirectory)/vsts
 
+- task: Docker@1
+  displayName: 'docker push atlasprivate.azurecr.io/atlas-cli'
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  inputs:
+    azureSubscriptionEndpoint: 'atlas-downloads'
+    azureContainerRegistry: atlasprivate.azurecr.io
+    command: 'Push an image'
+    imageName: 'atlas-cli:0.1.$(Build.BuildId)'
+    includeSourceTags: true
+
 - task: PublishBuildArtifacts@1
   displayName: publish artifacts
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+
+

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -5,9 +5,9 @@ steps:
     docker build -f Dockerfile.cli --target test --tag atlasprivate.azurecr.io/atlas-cli:test .
 
     testContainerName=test-$(Agent.Id)-$(System.DefinitionId)-$(Build.BuildId)
-    docker run --name $(testContainerName) atlasprivate.azurecr.io/atlas-cli:test
-    docker cp $(testContainerName):/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults/. $(Build.ArtifactStagingDirectory)/TestResults
-    docker rm $(testContainerName)
+    docker run --name ${testContainerName} atlasprivate.azurecr.io/atlas-cli:test
+    docker cp ${testContainerName}:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults/. $(Build.ArtifactStagingDirectory)/TestResults
+    docker rm ${testContainerName}
 
 - task: PublishTestResults@2
   inputs:

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -5,7 +5,7 @@ steps:
     publish_container_name=publish-$(Build.BuildId)
 
     build_args=""
-    build_args+=" --build-arg BUILD_ID=${BUILD_ID}"
+    build_args+=" --build-arg BUILD_BUILDID=${BUILD_BUILDID}"
     build_args+=" --build-arg BUILD_REPOSITORY_URI=${BUILD_REPOSITORY_URI}"
     build_args+=" --build-arg BUILD_SOURCEBRANCHNAME=${BUILD_SOURCEBRANCHNAME}"
     build_args+=" --build-arg BUILD_SOURCEVERSION=${BUILD_SOURCEVERSION}"

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -1,5 +1,39 @@
 steps:
 
+- task: Docker@1
+  displayName: 'Build atlas-cli runtime image'
+  inputs:
+    dockerFile: Dockerfile.cli
+    arguments: '--target runtime'
+    imageName: 'atlas-cli:0.1.$(Build.BuildId)'
+    qualifyImageName: false
+
+- task: Docker@1
+  displayName: 'Build atlas-cli test image'
+  inputs:
+    dockerFile: Dockerfile.cli
+    arguments: '--target test'
+    imageName: 'atlas-cli:test'
+    qualifyImageName: false
+
+- task: Docker@1
+  displayName: 'Run atlas-cli test image'
+  inputs:
+    command: 'Run an image'
+    imageName: 'atlas-cli:test'
+    qualifyImageName: false
+    volumes: '$(Build.ArtifactStagingDirectory)/TestResults:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults'
+    runInBackground: false
+
+- task: Docker@1
+  displayName: 'Push an image'
+  inputs:
+    azureSubscriptionEndpoint: 'atlas-downloads'
+    azureContainerRegistry: atlasprivate.azurecr.io
+    command: 'Push an image'
+    imageName: 'atlas-cli:0.1.$(Build.BuildId)'
+    includeSourceTags: true
+
 # Node Tool Installer
 # Finds or Downloads and caches specified version spec of Node and adds it to the PATH.
 - task: NodeTool@0
@@ -26,31 +60,6 @@ steps:
   continueOnError: true
   inputs:
     governanceProduct: '70f3e0d8-e9ab-e811-bce7-00155d7fb5a6'  
-
-- task: Docker@1
-  displayName: 'Build atlas-cli runtime image'
-  inputs:
-    dockerFile: Dockerfile.cli
-    arguments: '--target runtime'
-    imageName: 'atlas-cli:0.1.$(Build.BuildId)'
-    qualifyImageName: false
-
-- task: Docker@1
-  displayName: 'Build atlas-cli test image'
-  inputs:
-    dockerFile: Dockerfile.cli
-    arguments: '--target test'
-    imageName: 'atlas-cli:test'
-    qualifyImageName: false
-
-- task: Docker@1
-  displayName: 'Run atlas-cli test image'
-  inputs:
-    command: 'Run an image'
-    imageName: 'atlas-cli:test'
-    qualifyImageName: false
-    volumes: '$(Build.ArtifactStagingDirectory)/TestResults:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults'
-    runInBackground: false
 
 - task: DotNetCoreCLI@2
   displayName: dotnet build

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -1,20 +1,26 @@
 steps:
 
 - script: |
-    testContainerName=test-$(Build.BuildId)
-    publishContainerName=publish-$(Build.BuildId)
+    test_container_name=test-$(Build.BuildId)
+    publish_container_name=publish-$(Build.BuildId)
 
-    docker build -f Dockerfile.cli --target test --tag atlas-cli-test:0.1.$(Build.BuildId) .
-    docker run --name ${testContainerName} atlas-cli-test:0.1.$(Build.BuildId)
-    docker cp ${testContainerName}:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults/. $(Build.ArtifactStagingDirectory)/TestResults
-    docker rm ${testContainerName}
+    build_args=""
+    build_args+=" --build-arg BUILD_ID=${BUILD_ID}"
+    build_args+=" --build-arg BUILD_REPOSITORY_URI=${BUILD_REPOSITORY_URI}"
+    build_args+=" --build-arg BUILD_SOURCEBRANCHNAME=${BUILD_SOURCEBRANCHNAME}"
+    build_args+=" --build-arg BUILD_SOURCEVERSION=${BUILD_SOURCEVERSION}"
+    
+    docker build -f Dockerfile.cli ${build_args} --target test --tag atlas-cli-test:0.1.$(Build.BuildId) .
+    docker run --name ${test_container_name} atlas-cli-test:0.1.$(Build.BuildId)
+    docker cp ${test_container_name}:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults/. $(Build.ArtifactStagingDirectory)/TestResults
+    docker rm ${test_container_name}
 
-    docker build -f Dockerfile.cli --target publish --tag atlas-cli-publish:0.1.$(Build.BuildId) .
-    docker create --name ${publishContainerName} atlas-cli-publish:0.1.$(Build.BuildId)
-    docker cp ${publishContainerName}:/out/. $(Build.ArtifactStagingDirectory)
-    docker rm ${publishContainerName}
+    docker build -f Dockerfile.cli ${build_args} --target publish --tag atlas-cli-publish:0.1.$(Build.BuildId) .
+    docker create --name ${publish_container_name} atlas-cli-publish:0.1.$(Build.BuildId)
+    docker cp ${publish_container_name}:/out/. $(Build.ArtifactStagingDirectory)
+    docker rm ${publish_container_name}
 
-    docker build -f Dockerfile.cli --target runtime --tag atlasprivate.azurecr.io/atlas-cli:0.1.$(Build.BuildId) .
+    docker build -f Dockerfile.cli ${build_args} --target runtime --tag atlasprivate.azurecr.io/atlas-cli:0.1.$(Build.BuildId) .
 
 - task: PublishTestResults@2
   inputs:

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -1,29 +1,9 @@
 steps:
 
-- task: Docker@1
-  displayName: 'Build atlas-cli runtime image'
-  inputs:
-    dockerFile: Dockerfile.cli
-    arguments: '--target runtime'
-    imageName: 'atlas-cli:0.1.$(Build.BuildId)'
-    qualifyImageName: false
-
-- task: Docker@1
-  displayName: 'Build atlas-cli test image'
-  inputs:
-    dockerFile: Dockerfile.cli
-    arguments: '--target test'
-    imageName: 'atlas-cli:test'
-    qualifyImageName: false
-
-- task: Docker@1
-  displayName: 'Run atlas-cli test image'
-  inputs:
-    command: 'Run an image'
-    imageName: 'atlas-cli:test'
-    qualifyImageName: false
-    volumes: '$(Build.ArtifactStagingDirectory)/TestResults:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults'
-    runInBackground: false
+- script: |
+    docker build -f Dockerfile.cli --target runtime --tag atlasprivate.azurecr.io/atlas-cli:0.1.$(Build.BuildId) .
+    docker build -f Dockerfile.cli --target test --tag atlasprivate.azurecr.io/atlas-cli:test .
+    docker run --rm -v $(Build.ArtifactStagingDirectory)/TestResults:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults atlasprivate.azurecr.io/atlas-cli:test
 
 - task: Docker@1
   displayName: 'Push an image'

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -10,16 +10,19 @@ steps:
     build_args+=" --build-arg BUILD_SOURCEBRANCHNAME=${BUILD_SOURCEBRANCHNAME}"
     build_args+=" --build-arg BUILD_SOURCEVERSION=${BUILD_SOURCEVERSION}"
     
+    echo "docker build -f Dockerfile.cli --target test --tag atlas-cli-test:0.1.$(Build.BuildId)"
     docker build -f Dockerfile.cli ${build_args} --target test --tag atlas-cli-test:0.1.$(Build.BuildId) .
     docker run --name ${test_container_name} atlas-cli-test:0.1.$(Build.BuildId)
     docker cp ${test_container_name}:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults/. $(Build.ArtifactStagingDirectory)/TestResults
     docker rm ${test_container_name}
 
+    echo "docker build -f Dockerfile.cli --target publish --tag atlas-cli-publish:0.1.$(Build.BuildId)"
     docker build -f Dockerfile.cli ${build_args} --target publish --tag atlas-cli-publish:0.1.$(Build.BuildId) .
     docker create --name ${publish_container_name} atlas-cli-publish:0.1.$(Build.BuildId)
     docker cp ${publish_container_name}:/out/. $(Build.ArtifactStagingDirectory)
     docker rm ${publish_container_name}
 
+    echo "docker build -f Dockerfile.cli --target runtime --tag atlasprivate.azurecr.io/atlas-cli:0.1.$(Build.BuildId)"
     docker build -f Dockerfile.cli ${build_args} --target runtime --tag atlasprivate.azurecr.io/atlas-cli:0.1.$(Build.BuildId) .
 
 - task: PublishTestResults@2

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -27,6 +27,31 @@ steps:
   inputs:
     governanceProduct: '70f3e0d8-e9ab-e811-bce7-00155d7fb5a6'  
 
+- task: Docker@1
+  displayName: 'Build atlas-cli runtime image'
+  inputs:
+    dockerFile: Dockerfile.cli
+    arguments: '--target runtime'
+    imageName: 'atlas-cli:0.1.$(Build.BuildId)'
+    qualifyImageName: false
+
+- task: Docker@1
+  displayName: 'Build atlas-cli test image'
+  inputs:
+    dockerFile: Dockerfile.cli
+    arguments: '--target test'
+    imageName: 'atlas-cli:test'
+    qualifyImageName: false
+
+- task: Docker@1
+  displayName: 'Run atlas-cli test image'
+  inputs:
+    command: 'Run an image'
+    imageName: 'atlas-cli:test'
+    qualifyImageName: false
+    volumes: '$(Build.ArtifactStagingDirectory)/TestResults:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults'
+    runInBackground: false
+
 - task: DotNetCoreCLI@2
   displayName: dotnet build
 

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -10,18 +10,21 @@ steps:
     build_args+=" --build-arg BUILD_SOURCEBRANCHNAME=${BUILD_SOURCEBRANCHNAME}"
     build_args+=" --build-arg BUILD_SOURCEVERSION=${BUILD_SOURCEVERSION}"
     
+    # Create and run tests
     echo "docker build -f Dockerfile.cli --target test --tag atlas-cli-test:0.1.$(Build.BuildId)"
     docker build -f Dockerfile.cli ${build_args} --target test --tag atlas-cli-test:0.1.$(Build.BuildId) .
     docker run --name ${test_container_name} atlas-cli-test:0.1.$(Build.BuildId)
     docker cp ${test_container_name}:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults/. $(Build.ArtifactStagingDirectory)/TestResults
     docker rm ${test_container_name}
 
+    # Package artifacts to publish
     echo "docker build -f Dockerfile.cli --target publish --tag atlas-cli-publish:0.1.$(Build.BuildId)"
     docker build -f Dockerfile.cli ${build_args} --target publish --tag atlas-cli-publish:0.1.$(Build.BuildId) .
     docker create --name ${publish_container_name} atlas-cli-publish:0.1.$(Build.BuildId)
     docker cp ${publish_container_name}:/out/. $(Build.ArtifactStagingDirectory)
     docker rm ${publish_container_name}
 
+    # Build docker image to publish
     echo "docker build -f Dockerfile.cli --target runtime --tag atlasprivate.azurecr.io/atlas-cli:0.1.$(Build.BuildId)"
     docker build -f Dockerfile.cli ${build_args} --target runtime --tag atlasprivate.azurecr.io/atlas-cli:0.1.$(Build.BuildId) .
 

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -3,7 +3,11 @@ steps:
 - script: |
     docker build -f Dockerfile.cli --target runtime --tag atlasprivate.azurecr.io/atlas-cli:0.1.$(Build.BuildId) .
     docker build -f Dockerfile.cli --target test --tag atlasprivate.azurecr.io/atlas-cli:test .
-    docker run --rm -v $(Build.ArtifactStagingDirectory)/TestResults:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults atlasprivate.azurecr.io/atlas-cli:test
+
+    testContainerName=test-$(Agent.Id)-$(System.DefinitionId)-$(Build.BuildId)
+    docker run --name $(testContainerName) atlasprivate.azurecr.io/atlas-cli:test
+    docker cp $(testContainerName):/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults/. $(Build.ArtifactStagingDirectory)/TestResults
+    docker rm $(testContainerName)
 
 - task: PublishTestResults@2
   inputs:

--- a/build-ci.yaml
+++ b/build-ci.yaml
@@ -5,8 +5,14 @@ steps:
     docker build -f Dockerfile.cli --target test --tag atlasprivate.azurecr.io/atlas-cli:test .
     docker run --rm -v $(Build.ArtifactStagingDirectory)/TestResults:/app/test/Microsoft.Atlas.CommandLine.Tests/TestResults atlasprivate.azurecr.io/atlas-cli:test
 
+- task: PublishTestResults@2
+  inputs:
+    testRunner: VSTest
+    testResultsFiles: '$(Build.ArtifactStagingDirectory)/TestResults/*.trx'
+
 - task: Docker@1
-  displayName: 'Push an image'
+  displayName: 'Push atlas-cli to atlasprivate.azurecr.io'
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   inputs:
     azureSubscriptionEndpoint: 'atlas-downloads'
     azureContainerRegistry: atlasprivate.azurecr.io
@@ -44,11 +50,11 @@ steps:
 - task: DotNetCoreCLI@2
   displayName: dotnet build
 
-- task: DotNetCoreCLI@2
-  displayName: dotnet test
-  inputs:
-    command: test
-    projects: 'test/**/*.csproj'
+# - task: DotNetCoreCLI@2
+#   displayName: dotnet test
+#   inputs:
+#     command: test
+#     projects: 'test/**/*.csproj'
 
 - task: DotNetCoreCLI@2
   displayName: dotnet publish

--- a/examples/401-linux-agent-pool/templates/step2/azuredeploy.json
+++ b/examples/401-linux-agent-pool/templates/step2/azuredeploy.json
@@ -347,8 +347,9 @@
           "apiVersion": "2018-04-01",
           "location": "[parameters('location')]",
           "dependsOn": [
-            "[concat(variables('vmName'), copyIndex())]"
-          ],
+            "[concat(variables('vmName'), copyIndex())]",
+            "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(variables('vmName'), copyIndex()), 'DockerExtension')]"
+        ],
           "properties": {
             "publisher": "Microsoft.Azure.Extensions",
             "type": "CustomScript",
@@ -365,6 +366,22 @@
               "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2015-06-15').key1]"
             }
           }
+        },
+        {
+            "type": "extensions",
+            "name": "DockerExtension",
+            "apiVersion": "2017-03-30",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+              "[concat(variables('vmName'), copyIndex())]"
+            ],
+            "properties": {
+              "publisher": "Microsoft.Azure.Extensions",
+              "type": "DockerExtension",
+              "typeHandlerVersion": "1.0",
+              "autoUpgradeMinorVersion": true,
+              "settings": {}
+            }            
         }
       ]
     }

--- a/examples/401-linux-agent-pool/workflow.yaml
+++ b/examples/401-linux-agent-pool/workflow.yaml
@@ -50,7 +50,7 @@ operations:
     deployment:
       name: storage-and-keyvault-{{ guid (datetime add="PT0S") }}
       properties:
-        mode: Incremental
+        mode: Complete
         template: {{> templates/step1/azuredeploy.json }}
         parameters: 
           location:
@@ -83,8 +83,8 @@ operations:
       deploymentStatus: (result.body)
     repeat:
       condition: deploymentStatus.properties.provisioningState == 'Accepted' || deploymentStatus.properties.provisioningState == 'Running'
-      delay: PT5S
-      timeout: PT4M
+      delay: PT30S
+      timeout: PT90M
 
   - message: Deployment failed
     condition: deploymentStatus.properties.provisioningState != 'Succeeded'


### PR DESCRIPTION
* moves many steps from build-ci.yaml into dockerfile
* updates build agent arm template to include docker extension
* all publish artifacts now build through dockerfile
* tests are run in container
* a docker image is created for executing the atlas command without installing it

Resolves #94 