### PR TITLE
Adding base64_encode and base64_decode jmespath functions

### DIFF
--- a/src/Microsoft.Atlas.CommandLine/Queries/Base64DecodeFunction.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/Base64DecodeFunction.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using DevLab.JmesPath.Functions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Atlas.CommandLine.Queries
+{
+    public class Base64DecodeFunction : JmesPathFunction
+    {
+        public Base64DecodeFunction()
+            : base("base64_decode", 1)
+        {
+        }
+
+        public override void Validate(params JmesPathFunctionArgument[] args)
+        {
+            base.Validate();
+            EnsureArrayOrString(args[0]);
+        }
+
+        public override JToken Execute(params JmesPathFunctionArgument[] args)
+        {
+            var encoded = args[0].Token.Value<string>();
+            var decoded = Convert.FromBase64String(encoded);
+            var text = Encoding.UTF8.GetString(decoded);
+            return new JValue(text);
+        }
+    }
+}

--- a/src/Microsoft.Atlas.CommandLine/Queries/Base64EncodeFunction.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/Base64EncodeFunction.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using DevLab.JmesPath.Functions;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Atlas.CommandLine.Queries
+{
+    public class Base64EncodeFunction : JmesPathFunction
+    {
+        public Base64EncodeFunction()
+            : base("base64_encode", 1)
+        {
+        }
+
+        public override void Validate(params JmesPathFunctionArgument[] args)
+        {
+            base.Validate();
+            EnsureArrayOrString(args[0]);
+        }
+
+        public override JToken Execute(params JmesPathFunctionArgument[] args)
+        {
+            var text = args[0].Token.Value<string>();
+            var decoded = Encoding.UTF8.GetBytes(text);
+            var encoded = Convert.ToBase64String(decoded);
+            return new JValue(encoded);
+        }
+    }
+}

--- a/src/Microsoft.Atlas.CommandLine/Queries/JmesPathQuery.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/JmesPathQuery.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Atlas.CommandLine.Queries
                 .Register<ZipFunction>()
                 .Register<DistinctByFunction>()
                 .Register<DistinctFunction>()
+                .Register<Base64DecodeFunction>()
+                .Register<Base64EncodeFunction>()
                 .Register<BitsFunction>();
             _serializers = serializers;
         }

--- a/test/Microsoft.Atlas.CommandLine.Tests/Queries/Base64FunctionTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Queries/Base64FunctionTests.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Atlas.CommandLine.Queries;
+using Microsoft.Atlas.CommandLine.Serialization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Atlas.CommandLine.Tests.Queries
+{
+    [TestClass]
+    public class Base64FunctionTests : BaseFunctionTests
+    {
+        [TestMethod]
+        [DataRow("base64_encode('alpha')", "YWxwaGE=")]
+        [DataRow("base64_encode(data)", "YmV0YQ==")]
+        public void StringDataIsEncodedToBase64String(string expression, string expected)
+        {
+            var context = Yaml("data: beta");
+
+            var result = (string)Query.Search(expression, context);
+
+            Assert.AreEqual(expected, result);
+        }
+
+        [TestMethod]
+        [DataRow("base64_decode('YWxwaGE=')", "alpha")]
+        [DataRow("base64_decode(data)", "beta")]
+        public void Base64StringIsDecodedToString(string expression, string expected)
+        {
+            var context = Yaml("data: YmV0YQ==");
+
+            var result = (string)Query.Search(expression, context);
+
+            Assert.AreEqual(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
Needed to create kubeconfig.json files which contain ca.crt data