### PR TITLE
Allow swagger.extra to be a string literal

### DIFF
--- a/src/Microsoft.Atlas.CommandLine/Swagger/RequestGenerator.cs
+++ b/src/Microsoft.Atlas.CommandLine/Swagger/RequestGenerator.cs
@@ -82,7 +82,14 @@ namespace Microsoft.Atlas.CommandLine.Swagger
 
                 if (context.SwaggerReference.extra != null)
                 {
-                    writer.WriteLine(_yamlSerializers.YamlSerializer.Serialize(context.SwaggerReference.extra));
+                    if (context.SwaggerReference.extra is string extraString)
+                    {
+                        writer.WriteLine(extraString);
+                    }
+                    else
+                    {
+                        writer.WriteLine(_yamlSerializers.YamlSerializer.Serialize(context.SwaggerReference.extra));
+                    }
                 }
 
                 var bodyParameter = parameters.SingleOrDefault(parameter => parameter.@in == "body");


### PR DESCRIPTION

This makes complex scenarios possible where the extra data
needs to contain handlebars template markup which is incompatible
with a yaml file section