### PR TITLE
Adding search and concat jmespath functions

### DIFF
--- a/src/Microsoft.Atlas.CommandLine/Queries/ConcatFunction.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/ConcatFunction.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Atlas.CommandLine.Queries
             }
         }
 
-        private static string FormatAllowedDataTypes(string[] types)
+        public string FormatAllowedDataTypes(string[] types)
         {
             if (types.Length == 1)
             {

--- a/src/Microsoft.Atlas.CommandLine/Queries/ConcatFunction.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/ConcatFunction.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Linq;
+using System.Text;
+using DevLab.JmesPath.Functions;
+using DevLab.JmesPath.Utils;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Atlas.CommandLine.Queries
+{
+    public class ConcatFunction : JmesPathFunction
+    {
+        public ConcatFunction()
+            : base("concat", 0, true)
+        {
+        }
+
+        public override void Validate(params JmesPathFunctionArgument[] args)
+        {
+            base.Validate();
+
+            var types = new[] { "string" };
+            foreach (var arg in args)
+            {
+                var item = arg.Token;
+                if (!types.Contains(item.GetTokenType()))
+                {
+                    var valid = FormatAllowedDataTypes(types);
+                    throw new Exception($"Error: invalid-type, function {Name} expects an array of {valid}.");
+                }
+            }
+        }
+
+        private static string FormatAllowedDataTypes(string[] types)
+        {
+            if (types.Length == 1)
+            {
+                return types[0];
+            }
+
+            var valid = new StringBuilder();
+            valid.AppendFormat("{0} ", types[0]);
+            for (var index = 1; index < types.Length - 1; index++)
+            {
+                valid.AppendFormat(", {0} ", types[index]);
+            }
+
+            valid.AppendFormat("or {0}", types[types.Length - 1]);
+
+            return valid.ToString();
+        }
+
+        public override JToken Execute(params JmesPathFunctionArgument[] args)
+        {
+            var strings = args.Select(arg => arg.Token.Value<string>());
+
+            var result = string.Concat(strings);
+
+            return new JValue(result);
+        }
+    }
+}

--- a/src/Microsoft.Atlas.CommandLine/Queries/IJmesPathQuery.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/IJmesPathQuery.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
 namespace Microsoft.Atlas.CommandLine.Queries
@@ -6,5 +6,7 @@ namespace Microsoft.Atlas.CommandLine.Queries
     public interface IJmesPathQuery
     {
         object Search(string expression, object json);
+
+        string SearchJsonText(string expression, string jsonText);
     }
 }

--- a/src/Microsoft.Atlas.CommandLine/Queries/JmesPathQuery.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/JmesPathQuery.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Atlas.CommandLine.Queries
                 .Register<DistinctFunction>()
                 .Register<Base64DecodeFunction>()
                 .Register<Base64EncodeFunction>()
-                .Register<BitsFunction>();
+                .Register<BitsFunction>()
+                .Register<ConcatFunction>()
+                .Register("search", new SearchFunction(this));
             _serializers = serializers;
         }
 
@@ -39,6 +41,18 @@ namespace Microsoft.Atlas.CommandLine.Queries
                 var jsonOutput = _jmespath.Transform(jsonInput, expression);
                 var result = _serializers.YamlDeserializer.Deserialize<object>(jsonOutput);
                 return result;
+            }
+            catch (Exception ex)
+            {
+                throw new QueryException(ex.Message + Environment.NewLine + expression, ex) { Expression = expression };
+            }
+        }
+
+        public string SearchJsonText(string expression, string jsonText)
+        {
+            try
+            {
+                return _jmespath.Transform(jsonText, expression);
             }
             catch (Exception ex)
             {

--- a/src/Microsoft.Atlas.CommandLine/Queries/SearchFunction.cs
+++ b/src/Microsoft.Atlas.CommandLine/Queries/SearchFunction.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Text;
+using DevLab.JmesPath.Functions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Atlas.CommandLine.Queries
+{
+    public class SearchFunction : JmesPathFunction
+    {
+        private readonly IJmesPathQuery _jmesPathQuery;
+
+        public SearchFunction(IJmesPathQuery jmesPathQuery)
+            : base("search", 2)
+        {
+            _jmesPathQuery = jmesPathQuery;
+        }
+
+        public override void Validate(params JmesPathFunctionArgument[] args)
+        {
+            base.Validate();
+            EnsureArrayOrString(args[0]);
+        }
+
+        public override JToken Execute(params JmesPathFunctionArgument[] args)
+        {
+            var expr = args[0].Token.Value<string>();
+            var jsonInput = args[1].Token;
+
+            var jsonTextInput = JsonConvert.SerializeObject(jsonInput);
+            var jsonTextOutput = _jmesPathQuery.SearchJsonText(expr, jsonTextInput);
+            var jsonOutput = JToken.Parse(jsonTextOutput);
+
+            return jsonOutput;
+        }
+    }
+}

--- a/test/Microsoft.Atlas.CommandLine.Tests/Queries/ConcatFunctionTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Queries/ConcatFunctionTests.cs
@@ -61,7 +61,6 @@ data:
             Assert.AreEqual(1, result);
         }
 
-
         [TestMethod]
         public void ConcatCanBeEmpty()
         {

--- a/test/Microsoft.Atlas.CommandLine.Tests/Queries/ConcatFunctionTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Queries/ConcatFunctionTests.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Atlas.CommandLine.Tests.Queries
+{
+    [TestClass]
+    public class ConcatFunctionTests : BaseFunctionTests
+    {
+        [TestMethod]
+        public void StringsAreCombined()
+        {
+            var context = Yaml(@"
+find: two
+data:
+- name: one
+  value: 1
+- name: two
+  value: 2
+- name: three
+  value: 3");
+
+            var result = Query.Search(@"concat('a','b','c')", context);
+
+            Assert.AreEqual("abc", result);
+        }
+
+        [TestMethod]
+        public void ExpressionsCanBeInterpolated()
+        {
+            var context = Yaml(@"
+find: two
+data:
+- name: one
+  value: 1
+- name: two
+  value: 2
+- name: three
+  value: 3");
+
+            var result = Query.Search(@"concat('a', data[?value==`2`].name|[0], 'c')", context);
+
+            Assert.AreEqual("atwoc", result);
+        }
+
+        [TestMethod]
+        public void ConcatCanBuildSearchExpressions()
+        {
+            var context = Yaml(@"
+find: one
+data:
+  one: 1
+  two: 2
+  three: 3
+");
+
+            var result = Query.Search(@"search(concat('data.""', find, '""'), @) ", context);
+
+            Assert.AreEqual(1, result);
+        }
+
+
+        [TestMethod]
+        public void ConcatCanBeEmpty()
+        {
+            var context = Yaml(@"
+find: one
+data:
+  one: 1
+  two: 2
+  three: 3
+");
+
+            var result = Query.Search(@"concat()", context);
+
+            Assert.AreEqual(string.Empty, result);
+        }
+    }
+}

--- a/test/Microsoft.Atlas.CommandLine.Tests/Queries/SearchFunctionTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Queries/SearchFunctionTests.cs
@@ -22,7 +22,7 @@ data:
 - name: three
   value: 3");
 
-            var result = Query.Search(@"search(`""data[?name=='three']|[0].value""`, @) ", context);
+            var result = Query.Search(@"search('data[?name==\'three\']|[0].value', @) ", context);
 
             Assert.AreEqual(3, result);
         }
@@ -40,7 +40,7 @@ data:
 - name: three
   value: 3");
 
-            var result = Query.Search(@"search(join('', [`""data[?name=='""`, find, `""'] | [0].value""`]), @) ", context);
+            var result = Query.Search(@"search(concat('data[?name==\'', find, '\'] | [0].value'), @) ", context);
 
             Assert.AreEqual(2, result);
         }
@@ -56,7 +56,7 @@ data:
   three: 3
 ");
 
-            var result = Query.Search(@"search(join('', ['data.""', find, '""']), @) ", context);
+            var result = Query.Search(@"search(concat('data.""', find, '""'), @) ", context);
 
             Assert.AreEqual(1, result);
         }

--- a/test/Microsoft.Atlas.CommandLine.Tests/Queries/SearchFunctionTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Queries/SearchFunctionTests.cs
@@ -77,7 +77,6 @@ data:
             Assert.AreEqual(null, result);
         }
 
-
         [TestMethod]
         public void SearchResultCanBeAnObject()
         {

--- a/test/Microsoft.Atlas.CommandLine.Tests/Queries/SearchFunctionTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Queries/SearchFunctionTests.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Atlas.CommandLine.Tests.Queries
+{
+    [TestClass]
+    public class SearchFunctionTests : BaseFunctionTests
+    {
+        [TestMethod]
+        public void SearchRunsExpressionOnInput()
+        {
+            var context = Yaml(@"
+find: two
+data:
+- name: one
+  value: 1
+- name: two
+  value: 2
+- name: three
+  value: 3");
+
+            var result = Query.Search(@"search(`""data[?name=='three']|[0].value""`, @) ", context);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [TestMethod]
+        public void ExpressionCanBeBuiltToLookupArrayItem()
+        {
+            var context = Yaml(@"
+find: two
+data:
+- name: one
+  value: 1
+- name: two
+  value: 2
+- name: three
+  value: 3");
+
+            var result = Query.Search(@"search(join('', [`""data[?name=='""`, find, `""'] | [0].value""`]), @) ", context);
+
+            Assert.AreEqual(2, result);
+        }
+
+        [TestMethod]
+        public void ExpressionCanBeBuiltToLookupObjectProperty()
+        {
+            var context = Yaml(@"
+find: one
+data:
+  one: 1
+  two: 2
+  three: 3
+");
+
+            var result = Query.Search(@"search(join('', ['data.""', find, '""']), @) ", context);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [TestMethod]
+        public void SearchResultCanBeNull()
+        {
+            var context = Yaml(@"
+find: one
+data:
+  one: 1
+  two: 2
+  three: 3
+");
+
+            var result = Query.Search(@"search('data.four', @)", context);
+
+            Assert.AreEqual(null, result);
+        }
+
+
+        [TestMethod]
+        public void SearchResultCanBeAnObject()
+        {
+            var context = Yaml(@"
+find: one
+data:
+  one: 1
+  two: 2
+  three: 3
+");
+
+            var result = (IDictionary<object, object>)Query.Search(@"search('{four: sum([data.one, data.three])}', @)", context);
+
+            Assert.AreEqual(1, result.Count);
+            Assert.AreEqual(4, result["four"]);
+        }
+    }
+}


### PR DESCRIPTION
`concat(a,b,c)` is shorter form of `join('', [a,b,c])`

`search(expr, json)` is the same as the `search` pseudo function implied by http://jmespath.org/specification.html, except that the expr must be quoted if it is a string.

`search(' hello ', {hello: 'world'})` returns `"world"`, etc.

Together they can be used to make cleaner lookup expressions. For example, with the data:

``` yaml
current: two
things:
- name: one
  value: etc 1
- name: two
  value: etc 2
- name: three
  value: etc 3
````

The expression `search(concat('things[?name==\'', current, '\']'), @).value ` will return `['etc 2']`
