### PR TITLE
Removing readme.md as subworkflows are embedded

### DIFF
--- a/src/Microsoft.Atlas.CommandLine/Blueprints/BlueprintManager.cs
+++ b/src/Microsoft.Atlas.CommandLine/Blueprints/BlueprintManager.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Atlas.CommandLine.Blueprints
                     blueprintInfo = _yamlSerializers.YamlDeserializer.Deserialize<WorkflowInfoDocument>(yamlText);
                 }
 
-                blueprintPackage = new GeneratedReadmeBlueprintDecorator(blueprintPackage, "");
+                blueprintPackage = new GeneratedReadmeBlueprintDecorator(blueprintPackage, string.Empty);
             }
 
             foreach (var swaggerInfo in blueprintInfo.swagger.Values)

--- a/src/Microsoft.Atlas.CommandLine/Blueprints/BlueprintManager.cs
+++ b/src/Microsoft.Atlas.CommandLine/Blueprints/BlueprintManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Markdig.Syntax;
+using Microsoft.Atlas.CommandLine.Blueprints.Decorators;
 using Microsoft.Atlas.CommandLine.Blueprints.Models;
 using Microsoft.Atlas.CommandLine.Serialization;
 
@@ -35,7 +36,7 @@ namespace Microsoft.Atlas.CommandLine.Blueprints
             var blueprintPackageCore = GetBlueprintPackageCore(null, blueprint);
             if (blueprintPackageCore == null)
             {
-                return null;
+                throw new Exception($"Unable to find blueprint {blueprint}");
             }
 
             var blueprintPackage = await DecorateBlueprintPackage(blueprintPackageCore);
@@ -48,7 +49,7 @@ namespace Microsoft.Atlas.CommandLine.Blueprints
             var blueprintPackageCore = GetBlueprintPackageCore(parent, blueprint);
             if (blueprintPackageCore == null)
             {
-                return null;
+                throw new Exception($"Unable to find blueprint {blueprint}");
             }
 
             var blueprintPackage = await DecorateBlueprintPackage(blueprintPackageCore);
@@ -88,7 +89,9 @@ namespace Microsoft.Atlas.CommandLine.Blueprints
         {
             var blueprintInfo = new WorkflowInfoDocument();
 
-            if (blueprintPackageCore.Exists("readme.md"))
+            var blueprintPackage = blueprintPackageCore;
+
+            if (blueprintPackage.Exists("readme.md"))
             {
                 var readmeText = blueprintPackageCore.OpenText("readme.md").ReadToEnd();
                 var readmeDoc = Markdig.Markdown.Parse(readmeText);
@@ -103,9 +106,9 @@ namespace Microsoft.Atlas.CommandLine.Blueprints
 
                     blueprintInfo = _yamlSerializers.YamlDeserializer.Deserialize<WorkflowInfoDocument>(yamlText);
                 }
-            }
 
-            var blueprintPackage = blueprintPackageCore;
+                blueprintPackage = new GeneratedReadmeBlueprintDecorator(blueprintPackage, "");
+            }
 
             foreach (var swaggerInfo in blueprintInfo.swagger.Values)
             {

--- a/src/Microsoft.Atlas.CommandLine/Blueprints/Decorators/GeneratedReadmeBlueprintDecorator.cs
+++ b/src/Microsoft.Atlas.CommandLine/Blueprints/Decorators/GeneratedReadmeBlueprintDecorator.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.Atlas.CommandLine.Blueprints.Decorators
+{
+    public class GeneratedReadmeBlueprintDecorator : GeneratedFileBlueprintDecorator
+    {
+        public GeneratedReadmeBlueprintDecorator(IBlueprintPackage package, string readmeText)
+            : base(package)
+        {
+            GeneratedFiles["readme.md"] = readmeText;
+        }
+    }
+}

--- a/src/Microsoft.Atlas.CommandLine/Blueprints/Decorators/GeneratedReadmeBlueprintDecorator.cs
+++ b/src/Microsoft.Atlas.CommandLine/Blueprints/Decorators/GeneratedReadmeBlueprintDecorator.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 namespace Microsoft.Atlas.CommandLine.Blueprints.Decorators
 {
     public class GeneratedReadmeBlueprintDecorator : GeneratedFileBlueprintDecorator

--- a/test/Microsoft.Atlas.CommandLine.Tests/SubWorkflowTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/SubWorkflowTests.cs
@@ -343,7 +343,6 @@ Files:
             Assert.AreEqual(0, result);
         }
 
-
         [TestMethod]
         public async Task FileSystemTransitiveRelativeReferenceImportsFiles()
         {

--- a/test/Microsoft.Atlas.CommandLine.Tests/Swagger/SwaggerWorkflowTests.cs
+++ b/test/Microsoft.Atlas.CommandLine.Tests/Swagger/SwaggerWorkflowTests.cs
@@ -101,8 +101,8 @@ Responses:
             System.Console.Error.WriteLine(Console.ErrorStringWriter.ToString());
             System.Console.Out.WriteLine(Console.OutStringWriter.ToString());
 
-            Assert.AreEqual(1, generated.Count());
-            Assert.AreEqual(expectedPath, generated[0]);
+            Assert.AreEqual(2, generated.Count());
+            Assert.IsTrue(generated.Contains(expectedPath));
         }
 
         [TestMethod]


### PR DESCRIPTION
This avoids a bug where embedded workflows tried to read additional 
sub-workflows by relative path.