### PR TITLE
The commit fixes the build warning about: error NU5125: 

### DIFF
--- a/src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj
+++ b/src/Microsoft.Atlas.CommandLine/Microsoft.Atlas.CommandLine.csproj
@@ -11,6 +11,7 @@
     <PackAsTool>true</PackAsTool>
     <PackageId>atlas-cli</PackageId>
     <LangVersion>7.1</LangVersion>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
The commit fixes the build warning about: error NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead.